### PR TITLE
Show bookmark value in command message

### DIFF
--- a/src/main/java/seedu/address/logic/Messages.java
+++ b/src/main/java/seedu/address/logic/Messages.java
@@ -42,6 +42,8 @@ public class Messages {
                 .append(company.getEmail())
                 .append("; Address: ")
                 .append(company.getAddress())
+                .append("; Bookmark: ")
+                .append(company.getIsBookmark())
                 .append("; Tags: ");
         company.getTags().forEach(builder::append);
         return builder.toString();


### PR DESCRIPTION
Previously, after using the bookmark command, there was no value of bookmark indicated in the message of the UI.
This has been rectified by changing the `format` method in `Messages`.
However, this might cause users confusion as the message displayed is:
<img width="926" alt="image" src="https://github.com/user-attachments/assets/b75969fb-2ac3-475c-be87-19082a4900ed">
Although the company has been bookmarked, the bookmark value is false because **initially** the company was not bookmarked so the value is false. As a workaround, I will update the UG to allow users to take note of this point.