### PR TITLE
Fix remark and application status removing command

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -281,10 +281,12 @@ Format: `status INDEX as/STATUS`
 - The index refers to the index number shown in the displayed company list.
 - The index **must be a positive integer** 1, 2, 3, …​
 - The `STATUS` can be any text that describes the current application status.
+- You can remove the company's application status by typing `status INDEX as/` without specifying any text after `as/`.
 
 Examples:
 
 - `status 1 as/Applied` modifies the application status of the company at index 1 to `Applied`.
+- `status 2 as/` Removes the remark from the 2nd company.
 
 ### Clearing all entries : `clear`
 

--- a/src/main/java/seedu/address/logic/parser/ApplicationStatusCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/ApplicationStatusCommandParser.java
@@ -17,12 +17,13 @@ public class ApplicationStatusCommandParser implements Parser<ApplicationStatusC
 
     /**
      * Parses the given {@code String} of arguments in the context of the ApplicationStatusCommand
-     * and returns a ApplicationStatusCommand object for execution.
-     * @throws ParseException if the user input does not conform the expected format
+     * and returns an ApplicationStatusCommand object for execution.
+     * @throws ParseException if the user input does not conform to the expected format
      */
     public ApplicationStatusCommand parse(String args) throws ParseException {
         requireNonNull(args);
-        ArgumentMultimap argumentMultimap = ArgumentTokenizer.tokenize(args, PREFIX_APPLICATION_STATUS);
+        ArgumentMultimap argumentMultimap =
+                ArgumentTokenizer.tokenize(args, PREFIX_APPLICATION_STATUS);
 
         Index index;
         try {
@@ -31,9 +32,17 @@ public class ApplicationStatusCommandParser implements Parser<ApplicationStatusC
             throw new ParseException(
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, ApplicationStatusCommand.MESSAGE_USAGE), pe);
         }
-        String status = argumentMultimap.getValue(PREFIX_APPLICATION_STATUS).orElse("");
 
-        return new ApplicationStatusCommand(index, new ApplicationStatus(status));
+        // Ensure the 'as/' prefix is present
+        if (!argumentMultimap.getValue(PREFIX_APPLICATION_STATUS).isPresent()) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, ApplicationStatusCommand.MESSAGE_USAGE));
+        }
+
+        String statusValue = argumentMultimap.getValue(PREFIX_APPLICATION_STATUS).get();
+        ApplicationStatus status = new ApplicationStatus(statusValue);
+
+        return new ApplicationStatusCommand(index, status);
     }
 
 }

--- a/src/main/java/seedu/address/logic/parser/RemarkCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/RemarkCommandParser.java
@@ -33,7 +33,13 @@ public class RemarkCommandParser implements Parser<RemarkCommand> {
                     String.format(MESSAGE_INVALID_COMMAND_FORMAT, RemarkCommand.MESSAGE_USAGE), pe);
         }
 
-        String remarkValue = argMultimap.getValue(CliSyntax.PREFIX_REMARK).orElse("");
+        // Ensure the 'r/' prefix is present
+        if (!argMultimap.getValue(CliSyntax.PREFIX_REMARK).isPresent()) {
+            throw new ParseException(
+                    String.format(MESSAGE_INVALID_COMMAND_FORMAT, RemarkCommand.MESSAGE_USAGE));
+        }
+
+        String remarkValue = argMultimap.getValue(CliSyntax.PREFIX_REMARK).get();
         Remark remark = new Remark(remarkValue);
 
         return new RemarkCommand(index, remark);


### PR DESCRIPTION
Fix remark and application status so r/ and as/ is required to remove remarks and application status, also amended UG to align with the commands

close #145 
close #101 
close #106 